### PR TITLE
feat: Adds hook error_capture_log to report on trapped exceptions.

### DIFF
--- a/sentry/hooks.py
+++ b/sentry/hooks.py
@@ -25,6 +25,8 @@ app_include_js = ["https://cdn.ravenjs.com/3.18.1/raven.min.js",
 #                     "/assets/sentry/js/sentry-web.js"]
 
 exception_handlers = ["sentry.utils.handle"]
+# custom handler to report exceptions without necessarily breaking system flow
+error_capture_log = ["sentry.utils.handle"]
 
 boot_session = "sentry.boot.boot_session"
 

--- a/sentry/utils.py
+++ b/sentry/utils.py
@@ -16,7 +16,13 @@ def handle(async=True):
 
 
     client = Client(sentry_dsn, transport=transport)
-    if not frappe.conf.get("developer_mode"):
+    enabled = True
+    if frappe.conf.get("developer_mode"):
+        # You can set this in site_config.json
+        # ... enable_sentry_developer_mode: 1 ...
+        enabled = frappe.conf.get("enable_sentry_developer_mode", False)
+
+    if enabled:
         client.user_context({
             'email': frappe.session.user,
             'site' : frappe.local.site


### PR DESCRIPTION
Also adds a developer mode override to allow reporting on dev environments for testing.

In site_config.json:
```json
...
  "enable_sentry_developer_mode": 1
...
```