### PR TITLE
fix: py3 compatibility

### DIFF
--- a/sentry/utils.py
+++ b/sentry/utils.py
@@ -84,7 +84,7 @@ class HttpTransport(Transport):
 				self._send_event(event)
 
 
-def handle(async=True):
+def handle():
 	sentry_dsn = frappe.db.get_single_value("Sentry Settings", "sentry_dsn")
 
 	if not sentry_dsn:


### PR DESCRIPTION
```python
Error compiling '../apps/sentry/sentry/utils.py'...
  File "../apps/sentry/sentry/utils.py", line 87
    def handle(async=True):
                   ^
SyntaxError: invalid syntax
```