### PR TITLE
feat: pull DSN from the site config if it doesn't exist in the db

### DIFF
--- a/sentry/utils.py
+++ b/sentry/utils.py
@@ -88,6 +88,9 @@ def handle():
 	sentry_dsn = frappe.db.get_single_value("Sentry Settings", "sentry_dsn")
 
 	if not sentry_dsn:
+		sentry_dsn = frappe.conf.get("sentry_dsn")
+
+	if not sentry_dsn:
 		return
 
 	sentry_sdk.init(


### PR DESCRIPTION
This allows administrators to set the Sentry configuration "in bulk" via the `common_site_config.json` and also not having to access the instance DB. 